### PR TITLE
style: 관리자 로그인 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@tanstack/react-query-devtools": "^5.74.7",
         "next": "15.3.1",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zustand": "^5.0.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1372,7 +1373,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
       "integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2561,7 +2562,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7078,6 +7079,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
+      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@tanstack/react-query-devtools": "^5.74.7",
     "next": "15.3.1",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 import LongInput from '@/components/inputs/LongInput';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import BigButton from '@/components/buttons/BigButton';
 import { useRouter } from 'next/navigation';
-import { useUserInfoStore } from '@/store/useLoginStore';
 
 function AdminLogin() {
 	// 아이디 입력폼 컴포넌트
@@ -25,7 +24,6 @@ function AdminLogin() {
 	const router = useRouter();
 	const [loginErr, setLoginErr] = useState<string>('');
 	const [body, setBody] = useState<IPostLoginResquestType>({ username: '', password: '' });
-	const setUser = useUserInfoStore((state) => state.setUser);
 
 	// 테스트 로그인용 유저 => id: admin pw: 1234
 	const [isMount, setIsMount] = useState(false);
@@ -39,12 +37,6 @@ function AdminLogin() {
 		}
 
 		if (body.username === "admin" && body.password === "1234") {
-			setUser({
-				userId: idInputData,
-				// 로그인 시 서버에서 username에 대응되는 name을 받아와 대입
-				name: 'admin',
-				userRole: { userRole: "ADMIN" },
-			});
 			setLoginErr('');
 			router.push("/admin/main");
 		} else {

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -21,9 +21,11 @@ function AdminLogin() {
 	};
 
 	// 로그인 버튼 컴포넌트
+	interface Props extends IPostLoginResquestType {};
+	
 	const router = useRouter();
 	const [loginErr, setLoginErr] = useState<string>('');
-	const [body, setBody] = useState<IPostLoginResquestType>({ username: '', password: '' });
+	const [body, setBody] = useState<Props>({ username: '', password: '' });
 
 	// 테스트 로그인용 유저 => id: admin pw: 1234
 	const [isMount, setIsMount] = useState(false);

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -21,14 +21,12 @@ function AdminLogin() {
 	};
 
 	// 로그인 버튼 컴포넌트
-	interface Props extends IPostLoginResquestType {};
-	
 	const router = useRouter();
 	const [loginErr, setLoginErr] = useState<string>('');
-	const [body, setBody] = useState<Props>({ username: '', password: '' });
+	const [body, setBody] = useState<IPostLoginResquestType>({ username: '', password: '' });
 
 	// 테스트 로그인용 유저 => id: admin pw: 1234
-	const [isMount, setIsMount] = useState(false);
+	const [isMount, setIsMount] = useState<boolean>(false);
 	const handleTestSubmit = () => {
 		setBody({ username: idInputData, password: pwInputData })
 	};

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,11 +1,8 @@
 'use client';
 import LongInput from '@/components/inputs/LongInput';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import BigButton from '@/components/buttons/BigButton';
-import { useMutation } from '@tanstack/react-query';
-import api from '@/_lib/fetcher';
-import { IPostLoginResquestType, IPostLoginResponseType } from '@/types/LoginTypes';
 import { useRouter } from 'next/navigation';
 import { useUserInfoStore } from '@/store/useLoginStore';
 
@@ -29,30 +26,19 @@ function AdminLogin() {
 	const [loginErr, setLoginErr] = useState<string>('');
 	const [body, setBody] = useState<IPostLoginResquestType>({ username: '', password: '' });
 	const setUser = useUserInfoStore((state) => state.setUser);
-	const handleLogin = useMutation({
-		mutationFn: () => api.post<IPostLoginResquestType, IPostLoginResponseType>({
-			// 로그인 api로 변경
-			endpoint: '',
-			body: body,
-		}),
-		onSuccess: (data) => {
-			// api 요청 성공 시 로그인 로직
-			console.log(data);
-		},
-		onError: (err: unknown) => {
-			// api 요청 실패 시 처리
-			console.log(err);
-		}
-	});
-	const handleSubmit = () => {
-		setBody({ username: idInputData, password: pwInputData });
-		handleLogin.mutate();
-	};
 
-	// 테스트 로그인용 유저, handleTestSubmit 함수도 테스트용이므로 백엔드 연결시 handleLogin 함수에 새로 작성
-	const testUser = { username: "admin", password: "1234" };
+	// 테스트 로그인용 유저 => id: admin pw: 1234
+	const [isMount, setIsMount] = useState(false);
 	const handleTestSubmit = () => {
-		if (idInputData === "admin" && pwInputData === "1234") {
+		setBody({ username: idInputData, password: pwInputData })
+	};
+	useEffect(() => {
+		if(!isMount) {
+			setIsMount(true)
+			return;
+		}
+
+		if (body.username === "admin" && body.password === "1234") {
 			setUser({
 				userId: idInputData,
 				// 로그인 시 서버에서 username에 대응되는 name을 받아와 대입
@@ -64,7 +50,7 @@ function AdminLogin() {
 		} else {
 			setLoginErr('아이디 또는 비밀번호가 잘못되었습니다.');
 		};
-	};
+	}, [body])
 
 	return <div>
 		<div className='flex flex-col justify-center items-center h-[50vh]'>
@@ -101,7 +87,6 @@ function AdminLogin() {
 			<div>
 				<BigButton
 					buttonText='로그인'
-					// 로그인 로직 구현 시 handleSubmit 함수로 작성
 					handleClick={handleTestSubmit}
 				/>
 			</div>

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,8 +1,120 @@
 'use client';
-import React from 'react';
+import LongInput from '@/components/inputs/LongInput';
+import React, { useState } from 'react';
+import Image from 'next/image';
+import BigButton from '@/components/buttons/BigButton';
+import { useMutation } from '@tanstack/react-query';
+import api from '@/_lib/fetcher';
+import { IPostLoginResquestType, IPostLoginResponseType } from '@/types/LoginTypes';
+import { useRouter } from 'next/navigation';
+import { useUserInfoStore } from '@/store/useLoginStore';
 
 function AdminLogin() {
-	return <div>AdminLogin</div>;
+	// 아이디 입력폼 컴포넌트
+	const [idInputData, setIdInputData] = useState<string>('');
+	const handleIdInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const tirmmedId = e.target.value.trim();
+		setIdInputData(tirmmedId);
+	};
+
+	// 비밀번호 입력폼 컴포넌트
+	const [pwInputData, setPwInputData] = useState<string>('');
+	const handlePwInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const trimmedPw = e.target.value.trim();
+		setPwInputData(trimmedPw);
+	};
+
+	// 로그인 버튼 컴포넌트
+	const router = useRouter();
+	const [loginErr, setLoginErr] = useState<string>('');
+	const [body, setBody] = useState<IPostLoginResquestType>({ username: '', password: '' });
+	const setUser = useUserInfoStore((state) => state.setUser);
+	const handleLogin = useMutation({
+		mutationFn: () => api.post<IPostLoginResquestType, IPostLoginResponseType>({
+			// 로그인 api로 변경
+			endpoint: '',
+			body: body,
+		}),
+		onSuccess: (data) => {
+			// api 요청 성공 시 로그인 로직
+			console.log(data);
+		},
+		onError: (err: unknown) => {
+			// api 요청 실패 시 처리
+			console.log(err);
+		}
+	});
+	const handleSubmit = () => {
+		setBody({ username: idInputData, password: pwInputData });
+		handleLogin.mutate();
+	};
+
+	// 테스트 로그인용 유저, handleTestSubmit 함수도 테스트용이므로 백엔드 연결시 handleLogin 함수에 새로 작성
+	const testUser = { username: "admin", password: "1234" };
+	const handleTestSubmit = () => {
+		if (idInputData === "admin" && pwInputData === "1234") {
+			setUser({
+				userId: idInputData,
+				// 로그인 시 서버에서 username에 대응되는 name을 받아와 대입
+				name: 'admin',
+				userRole: { userRole: "ADMIN" },
+			});
+			setLoginErr('');
+			router.push("/admin/main");
+		} else {
+			setLoginErr('아이디 또는 비밀번호가 잘못되었습니다.');
+		};
+	};
+
+	return <div>
+		<div className='flex flex-col justify-center items-center h-[50vh]'>
+			<Image
+				src={'/logo/fatepetLogo.svg'}
+				width={220}
+				height={220}
+				alt='fatepet logo'
+			/>
+			<div className='font-bold text-2xl mt-3'>
+				업체관리
+			</div>
+		</div>
+		<div className='mx-2'>
+			<div className='mb-3'>
+				<LongInput
+					inputData={idInputData}
+					onChange={handleIdInputChange}
+					placeHolder='아이디'
+					disabled={false}
+					errorMsg=''
+				/>
+			</div>
+			<div className='mb-3'>
+				<LongInput
+					inputData={pwInputData}
+					onChange={handlePwInputChange}
+					placeHolder='비밀번호'
+					disabled={false}
+					errorMsg={loginErr}
+					inputType='password'
+				/>
+			</div>
+			<div>
+				<BigButton
+					buttonText='로그인'
+					// 로그인 로직 구현 시 handleSubmit 함수로 작성
+					handleClick={handleTestSubmit}
+				/>
+			</div>
+		</div>
+		<div className='flex flex-col text-gray-500 m-20'>
+			<div className='flex justify-center whitespace-nowrap'>
+				아이디/비밀번호 분실 시 고객센터로 문의주세요.
+			</div>
+			<div className='flex justify-center'>
+				fatepet@~~~.com
+			</div>
+		</div>
+	</div>
 }
 
 export default AdminLogin;

--- a/src/components/inputs/LongInput.tsx
+++ b/src/components/inputs/LongInput.tsx
@@ -7,6 +7,7 @@ interface Props {
 	placeHolder?: string;
 	onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 	errorMsg: string;
+	inputType?: string;
 }
 
 function LongInput({
@@ -15,6 +16,7 @@ function LongInput({
 	placeHolder,
 	onChange,
 	errorMsg,
+	inputType,
 }: Props) {
 	return (
 		<div className='w-full flex flex-col gap-[2px]'>
@@ -26,6 +28,7 @@ function LongInput({
 				placeholder={placeHolder}
 				onChange={onChange}
 				disabled={disabled}
+				type={inputType}
 			/>
 			<div className='text-[#FF0000] font-bold text-[12px]'>{errorMsg}</div>
 		</div>

--- a/src/store/useLoginStore.tsx
+++ b/src/store/useLoginStore.tsx
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+
+interface UserRoleType {
+    userRole: "ADMIN" | "CUSTOMER";
+};
+
+interface UserInfoType {
+    userId: string;
+    name: string;
+    userRole: UserRoleType;
+};
+
+interface UserStore {
+    user: UserInfoType;
+    setUser: (data: UserInfoType) => void;
+};
+
+const useUserInfoStore = create<UserStore>((set) => ({
+    user: {
+        userId: "",
+        name: "",
+        userRole: { userRole: "CUSTOMER" },
+    },
+    setUser: (data) => set({ user: data }),
+}));
+
+export { useUserInfoStore };

--- a/src/types/LoginTypes.d.ts
+++ b/src/types/LoginTypes.d.ts
@@ -1,7 +1,8 @@
-interface IPostLoginResquestType {
+// 관리자 로그인을 처리하기 위한 POST 메소드 타입
+type IPostLoginResquestType = {
     username: string;
     password: string;
 };
-interface IPostLoginResponseType {
+type IPostLoginResponseType = {
     success: boolean;
 };

--- a/src/types/LoginTypes.d.ts
+++ b/src/types/LoginTypes.d.ts
@@ -5,5 +5,3 @@ interface IPostLoginResquestType {
 interface IPostLoginResponseType {
     success: boolean;
 };
-
-export type { IPostLoginResquestType, IPostLoginResponseType };

--- a/src/types/LoginTypes.tsx
+++ b/src/types/LoginTypes.tsx
@@ -1,0 +1,9 @@
+interface IPostLoginResquestType {
+    username: string;
+    password: string;
+};
+interface IPostLoginResponseType {
+    success: boolean;
+};
+
+export type { IPostLoginResquestType, IPostLoginResponseType };


### PR DESCRIPTION
## #️⃣연관된 이슈

>1. #9 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)

> 1. 관리자의 로그인 페이지를 구현
> 2. 로그인 API POST시 사용할 req, res 타입 정의
> 3. 관리자 정보를 zustand를 이용해 전역변수로 생성

## 📝수정 내용(선택)

> 1. 로그인 시 input에서 password 처리를 위해 LongInput 컴포넌트에 type 속성을 optional로 추가

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/dd4fb20a-96fc-4147-be94-74a9fc847248)


## 💬리뷰 요구사항(선택)

> 1. 현재 로그인 로직은 API를 이용하는 대신 테스트용 유저를 생성해 임의로 진행중입니다. 추후에 API가 생성되는 대로 API를 이용하여 서버의 데이터를 이용하는 로직으로 수정하겠습니다.
> 2. 로그인을 위해 API를 처리하는 함수가 useMutation을 이용해 간단하게 작성되어있습니다. 이 부분은 아직 미숙하므로 수정이 필요한 부분이 있다면 디스코드나 깃허브 코멘트를 통해 조언해주시면 감사하겠습니다.