### PR TITLE
Style: 관리자 - 업체 상세 조회 페이지 업체 삭제 버튼 추가 및 모달 연결

### DIFF
--- a/src/app/admin/view-business/[businessId]/page.tsx
+++ b/src/app/admin/view-business/[businessId]/page.tsx
@@ -6,20 +6,39 @@ import PackageServiceList from '@/app/user/view-business/[category]/[businessId]
 import PrimaryServiceList from '@/app/user/view-business/[category]/[businessId]/_components/PrimaryServiceList';
 import TextWithUnderLine from '@/app/user/view-business/[category]/[businessId]/_components/TextWithUnderLine';
 import HeaderWithBackArrow from '@/components/headers/HeaderWithBackArrow';
+import CancelConfirmModal from '@/components/modals/CancelConfirmModal';
+import ModalLayout from '@/components/modals/ModalLayout';
 import BusinessCard from '@/components/user/BusinessCard';
 import { useParams, useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useState } from 'react';
 
 function AdminViewBusiness() {
 	const router = useRouter();
 	const params = useParams();
 	const businessId = params.businessId as string;
+	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
+
 	const handleBackArrowClick = () => {
 		router.back();
 	};
 
 	const handleGoEditBtnClick = () => {
-		router.push(`/admin/edit-business/${businessId}`)
+		router.push(`/admin/edit-business/${businessId}`);
+	};
+
+	const handleDeleteBtnClick = () => {
+		setIsDeleteModalOpen(true);
+	};
+
+	const handleCancelBtnClick = () => {
+		setIsDeleteModalOpen(false)
+	}
+
+	const handleBusinessDelete = () => {
+		// 업체 삭제 api 연동 로직
+
+		// 성공 시 
+		router.back();
 	}
 
 	return (
@@ -30,7 +49,19 @@ function AdminViewBusiness() {
 				hasRightConfirmButton={true}
 				handleRightButtonClick={handleGoEditBtnClick}
 				type='수정'
+				handleDeleteButtonClick={handleDeleteBtnClick}
 			/>
+			{isDeleteModalOpen && (
+				<ModalLayout setIsModalOpen={setIsDeleteModalOpen}>
+					<CancelConfirmModal
+						modalConfirmText='해당 업체를 정말 삭제하실 건가요?'
+						leftButtonText='업체 삭제'
+						rightButtonText='취소'
+						handleLeftButtonClick={handleBusinessDelete}
+						handleRightButtonClick={handleCancelBtnClick}
+					/>
+				</ModalLayout>
+			)}
 			<div className='flex flex-col gap-[52px] pb-[100px]'>
 				<BusinessCard
 					businessItem={{

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -291,6 +291,8 @@ export default function Main() {
 						modalConfirmText={`입력하신 정보가 저장되지 않았어요.\n업체 등록을 취소할까요?`}
 						handleLeftButtonClick={() => setIsCancelConfirmModalOpen(false)}
 						handleRightButtonClick={() => setIsCancelConfirmModalOpen(false)}
+						leftButtonText='등록 취소'
+						rightButtonText='계속 입력'
 					/>
 				</ModalLayout>
 			)}

--- a/src/components/buttons/MiniButton.tsx
+++ b/src/components/buttons/MiniButton.tsx
@@ -7,10 +7,14 @@ interface Props {
 }
 
 export const MiniButton = ({ buttonText, handleClick, isClicked }: Props) => {
-	let className = `font-bold text-[14px] rounded-[4px] px-[20px] min-w-[65px] h-[30px] border border-black whitespace-nowrap`;
+	let className = `font-bold text-[14px] rounded-[4px] px-[20px] min-w-[65px] h-[30px] whitespace-nowrap`;
 	if (buttonText === '로그아웃') {
 		className += ' text-white bg-p-black';
-	} else {
+	}
+	else if(buttonText === "삭제") {
+		className += " text-white bg-gray-middle"
+	}
+	else {
 		if (isClicked) {
 			className += ' bg-p-black text-white';
 		} else {

--- a/src/components/buttons/ModalButton.tsx
+++ b/src/components/buttons/ModalButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface Props {
-	buttonText: '등록 취소' | '계속 입력' | '확인';
+	buttonText: '등록 취소' | '계속 입력' | '확인' | "업체 삭제" | '취소';
 	handleClick: () => void;
 }
 
@@ -9,11 +9,11 @@ function ModalButton({ buttonText, handleClick }: Props) {
 	let className = 'h-[30px] rounded-[4px] font-bold text-[14px] cursor-pointer text-white';
 	if (buttonText === '확인') {
 		className += ' w-[65px] bg-p-black';
-	} else if (buttonText === '등록 취소') {
+	} else if (buttonText === '등록 취소' || buttonText === "업체 삭제") {
 		className += ' w-[92px] bg-p-red';
-	} else if (buttonText === '계속 입력') {
+	} else if (buttonText === '계속 입력' || buttonText === '취소') {
 		className += ' w-[92px] bg-p-black ';
-	}
+	} 
 
 	return (
 		<button className={className} onClick={handleClick}>

--- a/src/components/headers/HeaderWithBackArrow.tsx
+++ b/src/components/headers/HeaderWithBackArrow.tsx
@@ -7,7 +7,8 @@ interface Props {
 	handleBackArrowClick: () => void;
 	hasRightConfirmButton: boolean;
 	handleRightButtonClick?: () => void;
-	type?: "확인" | "수정"
+	type?: "확인" | "수정";
+	handleDeleteButtonClick?: () => void;
 }
 
 function HeaderWithBackArrow({
@@ -15,7 +16,8 @@ function HeaderWithBackArrow({
 	handleBackArrowClick,
 	hasRightConfirmButton,
 	handleRightButtonClick,
-	type = "확인"
+	type = "확인",
+	handleDeleteButtonClick
 }: Props) {
 	return (
 		<div className='w-full h-[51px] flex items-center relative text-black bg-white'>
@@ -29,14 +31,21 @@ function HeaderWithBackArrow({
 			<div className='text-[20px] font-black ml-[15px]'>{headerTitle}</div>
 			{hasRightConfirmButton && (
 				<div className='ml-auto'>
-					{type === "확인" ? <CompleteButton
-						size='small'
-						handleClick={handleRightButtonClick!}
-					/>
-						:
-						<MiniButton buttonText='정보 수정' handleClick={handleRightButtonClick!} isClicked={true} />
-				}
-					
+					{type === '확인' ? (
+						<CompleteButton
+							size='small'
+							handleClick={handleRightButtonClick!}
+						/>
+					) : (
+						<div className="flex gap-[5px]">
+							<MiniButton
+								buttonText='정보 수정'
+								handleClick={handleRightButtonClick!}
+								isClicked={true}
+								/>
+								<MiniButton buttonText='삭제' handleClick={handleDeleteButtonClick!} isClicked={false} />
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/src/components/modals/CancelConfirmModal.tsx
+++ b/src/components/modals/CancelConfirmModal.tsx
@@ -6,12 +6,16 @@ interface Props {
 	modalConfirmText: string;
 	handleLeftButtonClick: () => void;
 	handleRightButtonClick: () => void;
+	leftButtonText: '등록 취소' | '계속 입력' | '확인' | '업체 삭제' | '취소';
+	rightButtonText: '등록 취소' | '계속 입력' | '확인' | '업체 삭제' | '취소';
 }
 
 function CancelConfirmModal({
 	modalConfirmText,
 	handleLeftButtonClick,
 	handleRightButtonClick,
+	leftButtonText,
+	rightButtonText
 }: Props) {
 	return (
 		<div className='w-full py-[20px] h-[201px] max-w-[360px] rounded-[15px] text-[14px] font-bold text-black bg-white'>
@@ -27,11 +31,11 @@ function CancelConfirmModal({
 				</div>
 				<div className='flex gap-[10px]'>
 					<ModalButton
-						buttonText='등록 취소'
+						buttonText={leftButtonText}
 						handleClick={handleLeftButtonClick}
 					/>
 					<ModalButton
-						buttonText='계속 입력'
+						buttonText={rightButtonText}
 						handleClick={handleRightButtonClick}
 					/>
 				</div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #34 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)
> 1. 관리자 - 업체 상세 조회 페이지 업체 삭제 버튼 추가 및 모달 연결

## 📝수정 내용(선택)
> 1. MiniButton 컴포넌트에 buttonText가 "삭제"인 경우 추가
> 2. ModalButton 컴포넌트에 buttonText "업체 삭제", "취소" 추가
> 3. HeaderWithBackArrow 컴포넌트에 업체 삭제 경우를 위한 handleDeleteButtonClick props optional로 추가
> 4. CancelConfirmModal 컴포넌트에 "업체 삭제", "취소"버튼의 경우를 위해 props로 buttonText 받도록 수정

### 스크린샷 (선택)
<img width="456" alt="스크린샷 2025-05-15 오후 11 11 54" src="https://github.com/user-attachments/assets/7c244db4-0bb0-4322-a516-829d49107ab7" />
<img width="484" alt="스크린샷 2025-05-15 오후 11 12 05" src="https://github.com/user-attachments/assets/9329f1f2-dcab-4503-a93f-f707b3aba3a6" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?