### PR TITLE
Feat: 관리자 - 업체 삭제 api 연동 

### DIFF
--- a/src/_lib/apiRoutes.ts
+++ b/src/_lib/apiRoutes.ts
@@ -1,5 +1,7 @@
 export const apiRoutes = {
 	// 관리자
+	admin: '/admin',
+
 	// 인증관련
 	login: '/login',
 	reissue: '/token',

--- a/src/_lib/fetcher.ts
+++ b/src/_lib/fetcher.ts
@@ -46,7 +46,10 @@ const _fetch = async <T = unknown, R = unknown>(
 		credentials: 'include',
 	};
 
-	if (body) {
+	if (body instanceof FormData) {
+		delete headers['Content-Type'];
+		requestOptions.body = body;
+	} else if (body) {
 		requestOptions.body = JSON.stringify(body);
 	}
 

--- a/src/_lib/fetcher.ts
+++ b/src/_lib/fetcher.ts
@@ -37,7 +37,7 @@ const _fetch = async <T = unknown, R = unknown>(
 	};
 
 	if (authorization) {
-		headers.access = authorization;
+		headers.Authorization = `Bearer ${authorization}`;
 	}
 
 	const requestOptions: RequestInit = {
@@ -70,22 +70,20 @@ const _fetch = async <T = unknown, R = unknown>(
 				if (setAccessToken) {
 					setAccessToken('');
 				}
-				window.location.reload();
+				window.location.replace('/admin/login');
 				throw new Error('Failed to refreshToken');
 			}
 
 			// Bearer 포함 accessToken 값 헤더에서 추출
 			const newAccessToken = reissueResponse.headers.get('Authorization');
 			if (!newAccessToken) {
-				throw new Error('x-amzn-remapped-authorization header is missing');
+				throw new Error('Authorization is missing');
 			}
 
 			// Bearer 빼고 추출
 			const accessToken = newAccessToken.split(' ')[1];
 			if (!accessToken) {
-				throw new Error(
-					'Access token is missing in the  x-amzn-remapped-authorization header',
-				);
+				throw new Error('Access token is missing in the Authorization header');
 			}
 			if (setAccessToken) {
 				setAccessToken(accessToken);
@@ -109,39 +107,72 @@ const _fetch = async <T = unknown, R = unknown>(
 const _get = async <R = unknown>({
 	endpoint,
 	authorization,
+	setAccessToken,
 }: IGetOptions): Promise<R> => {
-	return _fetch<never, R>({ method: 'GET', endpoint, authorization });
+	return _fetch<never, R>({
+		method: 'GET',
+		endpoint,
+		authorization,
+		setAccessToken,
+	});
 };
 
 const _post = async <T = unknown, R = unknown>({
 	endpoint,
 	body,
 	authorization,
+	setAccessToken,
 }: IPostOptions<T>): Promise<R> => {
-	return _fetch<T, R>({ method: 'POST', endpoint, body, authorization });
+	return _fetch<T, R>({
+		method: 'POST',
+		endpoint,
+		body,
+		authorization,
+		setAccessToken,
+	});
 };
 
 const _patch = async <T = unknown, R = unknown>({
 	endpoint,
 	body,
 	authorization,
+	setAccessToken,
 }: IPostOptions<T>): Promise<R> => {
-	return _fetch<T, R>({ method: 'PATCH', endpoint, body, authorization });
+	return _fetch<T, R>({
+		method: 'PATCH',
+		endpoint,
+		body,
+		authorization,
+		setAccessToken,
+	});
 };
 
 const _put = async <T = unknown, R = unknown>({
 	endpoint,
 	body,
 	authorization,
+	setAccessToken,
 }: IPostOptions<T>): Promise<R> => {
-	return _fetch<T, R>({ method: 'PUT', endpoint, body, authorization });
+	return _fetch<T, R>({
+		method: 'PUT',
+		endpoint,
+		body,
+		authorization,
+		setAccessToken,
+	});
 };
 
 const _delete = async <R = unknown>({
 	endpoint,
 	authorization,
+	setAccessToken,
 }: IDeleteOptions): Promise<R> => {
-	return _fetch<never, R>({ method: 'DELETE', authorization, endpoint });
+	return _fetch<never, R>({
+		method: 'DELETE',
+		authorization,
+		endpoint,
+		setAccessToken,
+	});
 };
 
 const api = {

--- a/src/api/admin/business/deleteAdminBusiness.ts
+++ b/src/api/admin/business/deleteAdminBusiness.ts
@@ -1,0 +1,15 @@
+import { apiRoutes } from '@/_lib/apiRoutes';
+import api from '@/_lib/fetcher';
+
+export const deleteAdminBusiness = async (
+	authorization: string,
+	businessId: string,
+	setAccessToken: (accessToken: string) => void,
+) => {
+	const response = api.delete<IResponseType>({
+		endpoint: `${apiRoutes.admin}${apiRoutes.business}/${businessId}`,
+		authorization,
+		setAccessToken,
+	});
+	return response;
+};

--- a/src/api/admin/business/getAdminBusinessDetail.ts
+++ b/src/api/admin/business/getAdminBusinessDetail.ts
@@ -1,12 +1,15 @@
 import { apiRoutes } from '@/_lib/apiRoutes';
 import api from '@/_lib/fetcher';
 
-export const getAdminBusinessDetail = async (businessId: string, authorization: string) => {
+export const getAdminBusinessDetail = async (
+	businessId: string,
+	authorization: string,
+	setAccessToken: (accessToken: string) => void,
+) => {
 	const response: IGetBusinessDetailResponseType = await api.get({
 		endpoint: `${apiRoutes.business}/${businessId}`,
 		authorization,
+		setAccessToken,
 	});
-    return response;
+	return response;
 };
-
-

--- a/src/app/admin/view-business/[businessId]/page.tsx
+++ b/src/app/admin/view-business/[businessId]/page.tsx
@@ -8,6 +8,7 @@ import HeaderWithBackArrow from '@/components/headers/HeaderWithBackArrow';
 import CancelConfirmModal from '@/components/modals/CancelConfirmModal';
 import ModalLayout from '@/components/modals/ModalLayout';
 import BusinessCard from '@/components/user/BusinessCard';
+import { useDeleteAdminBusiness } from '@/hooks/api/admin/business/useDeleteAdminBusiness';
 import { useGetAdminBusinessDetail } from '@/hooks/api/admin/business/useGetAdminBusinessDetail';
 import useAuthStore from '@/store/useAuthStore';
 import { useParams, useRouter } from 'next/navigation';
@@ -18,10 +19,15 @@ function AdminViewBusiness() {
 	const params = useParams();
 	const businessId = params.businessId as string;
 	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
-	const { accessToken } = useAuthStore();
+	const { accessToken, setAccessToken } = useAuthStore();
 	const { data: businessDetail } = useGetAdminBusinessDetail(
 		businessId,
 		accessToken,
+	);
+	const { mutate: deleteBusiness } = useDeleteAdminBusiness(
+		accessToken,
+		businessId,
+		setAccessToken,
 	);
 
 	const handleBackArrowClick = () => {
@@ -41,10 +47,7 @@ function AdminViewBusiness() {
 	};
 
 	const handleBusinessDelete = () => {
-		// 업체 삭제 api 연동 로직
-
-		// 성공 시
-		router.back();
+		deleteBusiness();
 	};
 
 	if (!businessDetail) {

--- a/src/app/admin/view-business/[businessId]/page.tsx
+++ b/src/app/admin/view-business/[businessId]/page.tsx
@@ -23,6 +23,7 @@ function AdminViewBusiness() {
 	const { data: businessDetail } = useGetAdminBusinessDetail(
 		businessId,
 		accessToken,
+		setAccessToken
 	);
 	const { mutate: deleteBusiness } = useDeleteAdminBusiness(
 		accessToken,

--- a/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
+++ b/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
@@ -17,9 +17,11 @@ export const useDeleteAdminBusiness = (
 			deleteAdminBusiness(authorization, businessId, setAccessToken),
 		onSuccess: (data: IResponseType) => {
 			alert(data.message);
-			queryClient.invalidateQueries({
-				queryKey: ['ADMIN_BUSINESS_LIST'],
-			});
+			['ADMIN_BUSINESS_LIST', 'USER_BUSINESS_LIST'].forEach((key) =>
+				queryClient.invalidateQueries({
+					queryKey: [`${key}`],
+				}),
+			);
 			router.back();
 		},
 		onError: (error) => {

--- a/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
+++ b/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { deleteAdminBusiness } from '@/api/admin/business/deleteAdminBusiness';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export const useDeleteAdminBusiness = (
+	authorization: string,
+	businessId: string,
+	setAccessToken: (accessToken: string) => void,
+) => {
+	const queryClient = useQueryClient();
+	const router = useRouter();
+
+	return useMutation({
+		mutationFn: () =>
+			deleteAdminBusiness(authorization, businessId, setAccessToken),
+		onSuccess: (data: IResponseType) => {
+			alert(data.message);
+			queryClient.invalidateQueries({
+				queryKey: ['ADMIN_BUSINESS_LIST'],
+			});
+			router.back();
+		},
+		onError: (error) => {
+			alert(error.message);
+		},
+	});
+};

--- a/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
+++ b/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
@@ -15,8 +15,8 @@ export const useDeleteAdminBusiness = (
 	return useMutation({
 		mutationFn: () =>
 			deleteAdminBusiness(authorization, businessId, setAccessToken),
-		onSuccess: () => {
-			alert('삭제 성공');
+		onSuccess: (data: IResponseType) => {
+			alert(data.message);
 			['ADMIN_BUSINESS_LIST', 'USER_BUSINESS_LIST'].forEach((key) =>
 				queryClient.invalidateQueries({
 					queryKey: [`${key}`],

--- a/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
+++ b/src/hooks/api/admin/business/useDeleteAdminBusiness.ts
@@ -15,8 +15,8 @@ export const useDeleteAdminBusiness = (
 	return useMutation({
 		mutationFn: () =>
 			deleteAdminBusiness(authorization, businessId, setAccessToken),
-		onSuccess: (data: IResponseType) => {
-			alert(data.message);
+		onSuccess: () => {
+			alert('삭제 성공');
 			['ADMIN_BUSINESS_LIST', 'USER_BUSINESS_LIST'].forEach((key) =>
 				queryClient.invalidateQueries({
 					queryKey: [`${key}`],

--- a/src/hooks/api/admin/business/useGetAdminBusinessDetail.ts
+++ b/src/hooks/api/admin/business/useGetAdminBusinessDetail.ts
@@ -2,9 +2,14 @@
 import { getAdminBusinessDetail } from '@/api/admin/business/getAdminBusinessDetail';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetAdminBusinessDetail = (businessId: string, authorization: string) => {
+export const useGetAdminBusinessDetail = (
+	businessId: string,
+	authorization: string,
+	setAccessToken: (accessToken: string) => void,
+) => {
 	return useQuery({
 		queryKey: ['BUSINESS_DETAIL', businessId],
-		queryFn: () => getAdminBusinessDetail(businessId, authorization),
+		queryFn: () =>
+			getAdminBusinessDetail(businessId, authorization, setAccessToken),
 	});
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #56 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)
> 1. 관리자 - 업체 삭제 api 연동

## 📝수정 내용(선택)
> 1. fetcher에서 재발급 api 호출 시 403에러 떠도 무한 호출했던 오류 수정

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
> 지금 백엔드 디비에 목데이터가 한개 뿐이라서 삭제 테스트는 못해봤습니다. 데이터 추가로 넣어주면 테스트해볼게요