### PR TITLE
Fix: CancelConfirmModal 컴포넌트에서 확인, 취소 버튼 위치 뒤바꿈

### DIFF
--- a/src/_lib/apiRoutes.ts
+++ b/src/_lib/apiRoutes.ts
@@ -1,6 +1,6 @@
 export const apiRoutes = {
 	// 관리자
-	admin: '/admin',
+	admin: '/admin/business',
 
 	// 인증관련
 	login: '/login',

--- a/src/api/admin/business/deleteAdminBusiness.ts
+++ b/src/api/admin/business/deleteAdminBusiness.ts
@@ -7,7 +7,7 @@ export const deleteAdminBusiness = async (
 	setAccessToken: (accessToken: string) => void,
 ) => {
 	const response = api.delete<IResponseType>({
-		endpoint: `${apiRoutes.admin}${apiRoutes.business}/${businessId}`,
+		endpoint: `${apiRoutes.admin}/${businessId}`,
 		authorization,
 		setAccessToken,
 	});

--- a/src/app/admin/register-business/_components/ServiceCard.tsx
+++ b/src/app/admin/register-business/_components/ServiceCard.tsx
@@ -236,10 +236,10 @@ function ServiceCard({
 				<ModalLayout setIsModalOpen={setIsOpenServiceDeleteModal}>
 					<CancelConfirmModal
 						modalConfirmText={`입력하신 정보가 저장되지 않았어요.\n 해당 서비스를 정말 삭제하실 건가요?`}
-						handleLeftButtonClick={handleLeftButtonClick}
-						handleRightButtonClick={handleRightButtonClick}
-						leftButtonText='서비스 삭제'
-						rightButtonText='계속 입력'
+						handleRightButtonClick={handleLeftButtonClick}
+						handleLeftButtonClick={handleRightButtonClick}
+						rightButtonText='서비스 삭제'
+						leftButtonText='계속 입력'
 					/>
 				</ModalLayout>
 			)}

--- a/src/app/admin/view-business/[businessId]/page.tsx
+++ b/src/app/admin/view-business/[businessId]/page.tsx
@@ -69,10 +69,10 @@ function AdminViewBusiness() {
 				<ModalLayout setIsModalOpen={setIsDeleteModalOpen}>
 					<CancelConfirmModal
 						modalConfirmText='해당 업체를 정말 삭제하실 건가요?'
-						leftButtonText='업체 삭제'
-						rightButtonText='취소'
-						handleLeftButtonClick={handleBusinessDelete}
-						handleRightButtonClick={handleCancelBtnClick}
+						rightButtonText='업체 삭제'
+						leftButtonText='취소'
+						handleRightButtonClick={handleBusinessDelete}
+						handleLeftButtonClick={handleCancelBtnClick}
 					/>
 				</ModalLayout>
 			)}

--- a/src/components/modals/CancelConfirmModal.tsx
+++ b/src/components/modals/CancelConfirmModal.tsx
@@ -7,7 +7,7 @@ interface Props {
 	handleLeftButtonClick: () => void;
 	handleRightButtonClick: () => void;
 	leftButtonText: '등록 취소' | '계속 입력' | '확인' | '업체 삭제' | '취소' | '서비스 삭제';
-	rightButtonText: '등록 취소' | '계속 입력' | '확인' | '업체 삭제' | '취소';
+	rightButtonText: '등록 취소' | '계속 입력' | '확인' | '업체 삭제' | '취소' | '서비스 삭제';
 }
 
 function CancelConfirmModal({


### PR DESCRIPTION
## #️⃣연관된 이슈

> close #60 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)


## 📝수정 내용(선택)
> 1. CancelConfirmModal 컴포넌트의 확인, 취소 버튼 두버튼의 위치를 바꿈
> 2. apiRoutes에서 admin변수에 해당하는 api endpoint를 /admin/business로 수정

### 스크린샷 (선택)
<img width="184" alt="스크린샷 2025-05-25 오후 8 16 39" src="https://github.com/user-attachments/assets/aa4db923-f8cb-43d2-a80f-48fa2fedaf96" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?