### PR TITLE
Fix: 2차 QA 업체 등록 & 수정 

### DIFF
--- a/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
+++ b/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
@@ -122,7 +122,7 @@ function EditBusinessInfoArea({
 				if (value === '') {
 					handleErrorMsgs('hoursError', '운영시간을 입력해주세요.');
 				} else {
-					handleErrorMsgs('phoneError', '');
+					handleErrorMsgs('hoursError', '');
 				}
 				setPatchBusinessItem({
 					...patchBusinessItem,

--- a/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
+++ b/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
@@ -6,6 +6,7 @@ import RightButtonInput from '@/components/inputs/RightButtonInput';
 import DaumPost from '@/components/location/DaumPost';
 import ImageUploadButton from '../../../register-business/_components/ImageUploadButton';
 import { useCheckDuplicateName } from '@/hooks/admin-business/useCheckDuplicateName';
+import toast from 'react-hot-toast';
 
 const divClass = 'flex flex-col gap-[5px] font-bold';
 const requiredClass = 'text-p-red';
@@ -76,7 +77,11 @@ function EditBusinessInfoArea({
 	}, [address, detailAddress]);
 
 	const handleCategoryClick = (category: string) => {
-		setPatchBusinessItem({ ...patchBusinessItem, category: category });
+		if (category === '장묘') {
+			setPatchBusinessItem({ ...patchBusinessItem, category: category });
+		} else {
+			toast.error('아직 준비중인 서비스입니다.');
+		}
 	};
 
 	const onInputChange = (

--- a/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
+++ b/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
@@ -127,6 +127,10 @@ function EditBusinessInfoArea({
 					onChange={(e) => onInputChange('업체명', e)}
 					buttonText='중복확인'
 					handleButtonClick={checkDuplicateName}
+					disabled={
+						patchBusinessItem.name === null ||
+						patchBusinessItem.name === originBusinessItem.name
+					}
 				/>
 			</div>
 			<div className={divClass}>

--- a/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
+++ b/src/app/admin/edit-business/[businessId]/_components/EditBusinessInfoArea.tsx
@@ -13,6 +13,9 @@ const requiredClass = 'text-p-red';
 
 interface Props {
 	originBusinessItem: IBusinessDetailDataType;
+	setOriginBusinessItem: React.Dispatch<
+		React.SetStateAction<IBusinessDetailDataType>
+	>;
 	patchBusinessItem: IPatchBusinessRequestType;
 	setPatchBusinessItem: React.Dispatch<
 		React.SetStateAction<IPatchBusinessRequestType>
@@ -33,6 +36,7 @@ function EditBusinessInfoArea({
 	errorMsgs,
 	setErrorMsgs,
 	originBusinessItem,
+	setOriginBusinessItem,
 	patchBusinessItem,
 	setPatchBusinessItem,
 	imageFile,
@@ -84,37 +88,78 @@ function EditBusinessInfoArea({
 		}
 	};
 
+	const handleErrorMsgs = (errType: string, msg: string) => {
+		setErrorMsgs((prev) => ({
+			...prev,
+			[errType]: msg,
+		}));
+	};
+
+	const isValidPhoneNumber = (phoneNumber: string): boolean => {
+		const regex = /^010\d{8}$/;
+		return regex.test(phoneNumber);
+	};
+
 	const onInputChange = (
 		type: string,
 		e: React.ChangeEvent<HTMLInputElement>,
 	) => {
+		const value = e.target.value;
+
 		switch (type) {
 			case '업체명':
-				setPatchBusinessItem({ ...patchBusinessItem, name: e.target.value });
+				if (value === '') {
+					handleErrorMsgs('nameError', '업체명을 입력해주세요.');
+				} else if (!isCheckedName) {
+					handleErrorMsgs('nameError', '업체명을 중복확인을 해주세요.');
+				} else {
+					handleErrorMsgs('nameError', '');
+				}
+				setPatchBusinessItem({ ...patchBusinessItem, name: value });
 				setIsCheckedName(false);
 				break;
 			case '운영시간':
+				if (value === '') {
+					handleErrorMsgs('hoursError', '운영시간을 입력해주세요.');
+				} else {
+					handleErrorMsgs('phoneError', '');
+				}
 				setPatchBusinessItem({
 					...patchBusinessItem,
-					businessHours: e.target.value,
+					businessHours: value,
 				});
 				break;
 			case '번호':
+				if (value === '') {
+					handleErrorMsgs('phoneError', '휴대폰번호를 입력해주세요.');
+				} else if (!isValidPhoneNumber(value)) {
+					handleErrorMsgs('phoneError', '형식이 올바르지 않습니다.');
+				} else {
+					handleErrorMsgs('phoneError', '');
+				}
 				setPatchBusinessItem({
 					...patchBusinessItem,
-					phoneNumber: e.target.value,
+					phoneNumber: value,
 				});
 				break;
 			case '이메일':
-				setPatchBusinessItem({ ...patchBusinessItem, email: e.target.value });
+				if (value === '') {
+					handleErrorMsgs('emailError', '이메일을 입력해주세요.');
+				} else {
+					handleErrorMsgs('emailError', '');
+				}
+				setPatchBusinessItem({ ...patchBusinessItem, email: value });
 				break;
 			case '상세주소':
-				setDetailAddress(e.target.value);
+				setDetailAddress(value);
 				break;
 		}
 	};
 
 	const handleDeleteImage = () => {
+		if (originBusinessItem.mainImageUrl !== '') {
+			setOriginBusinessItem((prev) => ({ ...prev, mainImageUrl: '' }));
+		}
 		setImageFile(null);
 		setImgPreview(null);
 	};

--- a/src/app/admin/edit-business/[businessId]/page.tsx
+++ b/src/app/admin/edit-business/[businessId]/page.tsx
@@ -9,6 +9,7 @@ import { usePatchEditBusiness } from '@/hooks/api/admin/business/usePatchEditBus
 import EditBusinessInfoArea from './_components/EditBusinessInfoArea';
 import EditServiceInfoArea from './_components/EditServiceInfoArea';
 import EditAdditionalInfoArea from './_components/EditAdditionalInfoArea';
+import toast from 'react-hot-toast';
 
 const areaNameClass = 'font-bold text-[14px] text-gray-middle mt-[10px]';
 const borderClass = 'w-[100%] h-[1px] bg-gray-middle mb-[10px]';
@@ -206,54 +207,51 @@ function EditBusiness() {
 		return regex.test(phoneNumber);
 	};
 
-	const handleCheckErrorMsgs = (): boolean => {
-		const newErrors = { ...errorMsgs };
-
+	const handleCheckErrorMsgs = () => {
 		if (patchBusinessItem.name === '') {
-			newErrors.nameError = '업체명을 입력해주세요.';
+			toast.error('업체명을 입력해주세요.');
+			return;
 		} else if (!isCheckedName) {
-			newErrors.nameError = '업체명 중복확인을 해주세요.';
-		} else {
-			newErrors.nameError = '';
+			toast.error('업체명 중복확인을 해주세요.');
+			return;
 		}
+
+		if (originBusinessItem.mainImageUrl === '' && patchMainImageFile === null) {
+			toast.error('대표사진을 등록해주세요.');
+			return;
+		}
+
 		if (patchBusinessItem.businessHours === '') {
-			newErrors.hoursError = '운영시간을 입력해주세요.';
-		} else {
-			newErrors.hoursError = '';
+			toast.error('운영시간을 입력해주세요.');
+			return;
 		}
+
 		if (patchBusinessItem.phoneNumber === '') {
-			newErrors.phoneError = '휴대폰번호를 입력해주세요.';
+			toast.error('휴대폰번호를 입력해주세요.');
+			return;
 		} else if (
 			!isValidPhoneNumber(
 				patchBusinessItem.phoneNumber ?? originBusinessItem.phoneNumber,
 			)
 		) {
-			newErrors.phoneError = '형식이 올바르지 않습니다.';
-		} else {
-			newErrors.phoneError = '';
+			toast.error('휴대폰번호 형식이 올바르지 않습니다.');
+			return;
 		}
 		if (patchBusinessItem.email === '') {
-			newErrors.emailError = '이메일을 입력해주세요.';
-		} else {
-			newErrors.emailError = '';
+			toast.error('이메일을 입력해주세요.');
+			return;
 		}
 		if (patchBusinessItem.address === '') {
-			newErrors.addressError = '주소를 설정해주세요.';
-		} else {
-			newErrors.addressError = '';
-		}
-		setErrorMsgs(newErrors);
-
-		if (Object.values(newErrors).every((msg) => msg === '')) {
-			return true;
-		} else {
-			return false;
+			toast.error('주소를 설정해주세요.');
+			return;
 		}
 	};
 
 	const handleBusinessRegisterButton = () => {
+		handleCheckErrorMsgs();
 		if (
-			handleCheckErrorMsgs() &&
+			(originBusinessItem.mainImageUrl !== '' || patchMainImageFile !== null) &&
+			Object.values(errorMsgs).every((msg) => msg === '') &&
 			Object.values(serviceErrorMsgs).every((msg) => msg === '')
 		) {
 			editBusiness(patchBusinessItem);
@@ -274,6 +272,7 @@ function EditBusiness() {
 					<div className={borderClass} />
 					<EditBusinessInfoArea
 						originBusinessItem={originBusinessItem}
+						setOriginBusinessItem={setOriginBusinessItem}
 						patchBusinessItem={patchBusinessItem}
 						setPatchBusinessItem={setPatchBusinessItem}
 						errorMsgs={errorMsgs}

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -121,6 +121,7 @@ function BusinessInfoArea({
 					onChange={(e) => onInputChange('업체명', e)}
 					buttonText='중복확인'
 					handleButtonClick={checkDuplicateName}
+					disabled={businessItem.name === ''}
 				/>
 			</div>
 			<div className={divClass}>

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -84,22 +84,53 @@ function BusinessInfoArea({
 		}
 	};
 
+	const handleErrorMsgs = (errType: string, msg: string) => {
+		setErrorMsgs((prev) => ({
+			...prev,
+			[errType]: msg,
+		}));
+	};
+
 	const onInputChange = (
 		type: string,
 		e: React.ChangeEvent<HTMLInputElement>,
 	) => {
+		const value = e.target.value;
+
 		switch (type) {
 			case '업체명':
+				if (value === '') {
+					handleErrorMsgs('nameError', '업체명을 입력해주세요.');
+				} else if (!isCheckedName) {
+					handleErrorMsgs('nameError', '업체명을 중복확인을 해주세요.');
+				} else {
+					handleErrorMsgs('nameError', '');
+				}
 				setBusinessItem({ ...businessItem, name: e.target.value });
 				setIsCheckedName(false);
 				break;
 			case '운영시간':
+				if (value === '') {
+					handleErrorMsgs('hoursError', '운영시간을 입력해주세요.');
+				} else {
+					handleErrorMsgs('phoneError', '');
+				}
 				setBusinessItem({ ...businessItem, businessHours: e.target.value });
 				break;
 			case '번호':
+				if (value === '') {
+					handleErrorMsgs('phoneError', '휴대폰번호를 입력해주세요.');
+				} else {
+					handleErrorMsgs('phoneError', '');
+				}
 				setBusinessItem({ ...businessItem, phoneNumber: e.target.value });
 				break;
 			case '이메일':
+				if (value === '') {
+					handleErrorMsgs('emailError', '이메일을 입력해주세요.');
+				} else {
+					handleErrorMsgs('emailError', '');
+				}
 				setBusinessItem({ ...businessItem, email: e.target.value });
 				break;
 			case '상세주소':

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -91,6 +91,11 @@ function BusinessInfoArea({
 		}));
 	};
 
+	const isValidPhoneNumber = (phoneNumber: string): boolean => {
+		const regex = /^010\d{8}$/;
+		return regex.test(phoneNumber);
+	};
+
 	const onInputChange = (
 		type: string,
 		e: React.ChangeEvent<HTMLInputElement>,
@@ -120,6 +125,8 @@ function BusinessInfoArea({
 			case '번호':
 				if (value === '') {
 					handleErrorMsgs('phoneError', '휴대폰번호를 입력해주세요.');
+				} else if (!isValidPhoneNumber(value)) {
+					handleErrorMsgs('phoneError', '형식이 올바르지 않습니다.');
 				} else {
 					handleErrorMsgs('phoneError', '');
 				}

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -5,8 +5,6 @@ import ImageUploadButton from './ImageUploadButton';
 import DeleteButton from '@/components/buttons/DeleteButton';
 import RightButtonInput from '@/components/inputs/RightButtonInput';
 import DaumPost from '@/components/location/DaumPost';
-import { useGetCheckBusinessName } from '@/hooks/api/admin/business/useGetCheckBusinessName';
-import useAuthStore from '@/store/useAuthStore';
 import { useCheckDuplicateName } from '@/hooks/admin-business/useCheckDuplicateName';
 import toast from 'react-hot-toast';
 

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -113,7 +113,7 @@ function BusinessInfoArea({
 				if (value === '') {
 					handleErrorMsgs('hoursError', '운영시간을 입력해주세요.');
 				} else {
-					handleErrorMsgs('phoneError', '');
+					handleErrorMsgs('hoursError', '');
 				}
 				setBusinessItem({ ...businessItem, businessHours: e.target.value });
 				break;

--- a/src/app/admin/register-business/_components/BusinessInfoArea.tsx
+++ b/src/app/admin/register-business/_components/BusinessInfoArea.tsx
@@ -8,6 +8,7 @@ import DaumPost from '@/components/location/DaumPost';
 import { useGetCheckBusinessName } from '@/hooks/api/admin/business/useGetCheckBusinessName';
 import useAuthStore from '@/store/useAuthStore';
 import { useCheckDuplicateName } from '@/hooks/admin-business/useCheckDuplicateName';
+import toast from 'react-hot-toast';
 
 const divClass = 'flex flex-col gap-[5px] font-bold';
 const requiredClass = 'text-p-red';
@@ -76,7 +77,11 @@ function BusinessInfoArea({
 	}, [address, detailAddress]);
 
 	const handleCategoryClick = (category: string) => {
-		setBusinessItem({ ...businessItem, category: category });
+		if (category === '장묘') {
+			setBusinessItem({ ...businessItem, category: category });
+		} else {
+			toast.error('아직 준비중인 서비스입니다.');
+		}
 	};
 
 	const onInputChange = (

--- a/src/app/admin/register-business/page.tsx
+++ b/src/app/admin/register-business/page.tsx
@@ -8,6 +8,7 @@ import AdditionalInfoArea from './_components/AdditionalInfoArea';
 import { convertAddressToCoordinates } from '@/hooks/admin-business/useConvertAddressToCoordinates';
 import useAuthStore from '@/store/useAuthStore';
 import { usePostCreateBusiness } from '@/hooks/api/admin/business/usePostCreateBusiness';
+import toast from 'react-hot-toast';
 
 const areaNameClass = 'font-bold text-[14px] text-gray-middle mt-[10px]';
 const borderClass = 'w-[100%] h-[1px] bg-gray-middle mb-[10px]';
@@ -104,52 +105,49 @@ function RegisterBusiness() {
 	};
 
 	const handleBusinessRegisterButton = () => {
+		handleCheckErrorMsgs();
 		if (
-			handleCheckErrorMsgs() &&
+			businessItem.mainImage !== null &&
+			Object.values(errorMsgs).every((msg) => msg === '') &&
 			Object.values(serviceErrorMsgs).every((msg) => msg === '')
 		) {
 			createBusiness(businessItem);
 		}
 	};
 
-	const handleCheckErrorMsgs = (): boolean => {
-		const newErrors = { ...errorMsgs };
-
+	const handleCheckErrorMsgs = () => {
 		if (businessItem.name === '') {
-			newErrors.nameError = '업체명을 입력해주세요.';
+			toast.error('업체명을 입력해주세요.');
+			return;
 		} else if (!isCheckedName) {
-			newErrors.nameError = '업체명 중복확인을 해주세요.';
-		} else {
-			newErrors.nameError = '';
+			toast.error('업체명 중복확인을 해주세요.');
+			return;
 		}
+
+		if (thumbnailFile === null) {
+			toast.error('대표사진을 등록해주세요.');
+			return;
+		}
+
 		if (businessItem.businessHours === '') {
-			newErrors.hoursError = '운영시간을 입력해주세요.';
-		} else {
-			newErrors.hoursError = '';
+			toast.error('운영시간을 입력해주세요.');
+			return;
 		}
+
 		if (businessItem.phoneNumber === '') {
-			newErrors.phoneError = '휴대폰번호를 입력해주세요.';
-		} else if (!isValidPhoneNumber(businessItem.phoneNumber ?? '')) {
-			newErrors.phoneError = '형식이 올바르지 않습니다.';
-		} else {
-			newErrors.phoneError = '';
+			toast.error('휴대폰번호를 입력해주세요.');
+			return;
+		} else if (!isValidPhoneNumber(businessItem.phoneNumber)) {
+			toast.error('휴대폰번호 형식이 올바르지 않습니다.');
+			return;
 		}
 		if (businessItem.email === '') {
-			newErrors.emailError = '이메일을 입력해주세요.';
-		} else {
-			newErrors.emailError = '';
+			toast.error('이메일을 입력해주세요.');
+			return;
 		}
 		if (businessItem.address === '') {
-			newErrors.addressError = '주소를 설정해주세요.';
-		} else {
-			newErrors.addressError = '';
-		}
-		setErrorMsgs(newErrors);
-
-		if (Object.values(newErrors).every((msg) => msg === '')) {
-			return true;
-		} else {
-			return false;
+			toast.error('주소를 설정해주세요.');
+			return;
 		}
 	};
 

--- a/src/components/buttons/MediumButton.tsx
+++ b/src/components/buttons/MediumButton.tsx
@@ -3,13 +3,20 @@ import React from 'react';
 interface Props {
 	buttonText: string;
 	handleClick: () => void;
+	disabled: boolean;
 }
 
-function MediumButton({ buttonText, handleClick }: Props) {
+function MediumButton({ buttonText, handleClick, disabled }: Props) {
 	return (
 		<button
-			className='miax-w-[89px] h-[38px] rounded-[4px] px-[20px] flex justify-center items-center text-white font-bold text-[13px] cursor-pointer bg-p-black whitespace-nowrap'
-			onClick={handleClick}
+			className={`max-w-[89px] h-[38px] rounded-[4px] px-[20px] flex justify-center items-center ${disabled ? 'text-gray-middle bg-gray-lite' : 'text-white bg-p-black'} font-bold text-[13px] cursor-pointer whitespace-nowrap`}
+			onClick={() => {
+				disabled
+					? () => {
+							return;
+						}
+					: handleClick();
+			}}
 		>
 			{buttonText}
 		</button>

--- a/src/components/inputs/RightButtonInput.tsx
+++ b/src/components/inputs/RightButtonInput.tsx
@@ -10,6 +10,7 @@ interface Props {
 	inputType?: string;
 	buttonText: string;
 	handleButtonClick: () => void;
+	disabled: boolean;
 }
 
 function RightButtonInput({
@@ -20,6 +21,7 @@ function RightButtonInput({
 	inputType,
 	buttonText,
 	handleButtonClick,
+	disabled,
 }: Props) {
 	return (
 		<div className='w-full flex flex-col gap-[2px]'>
@@ -31,7 +33,11 @@ function RightButtonInput({
 					onChange={onChange}
 					type={inputType}
 				/>
-				<MediumButton buttonText={buttonText} handleClick={handleButtonClick} />
+				<MediumButton
+					buttonText={buttonText}
+					handleClick={handleButtonClick}
+					disabled={disabled}
+				/>
 			</div>
 			<div className='text-[#FF0000] font-bold text-[12px]'>{errorMsg}</div>
 		</div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex. #94 

## 📝작업 내용(이번 PR에서 작업한 내용을 간략히 설명)
> 1. 

## 📝수정 내용(선택)
-  업체 수정- 업체명 수정 전에는 중복확인 버튼 비활성화 되도록
-   업체 등록도 업체명 입력 전에 버튼 비활성화 되도록 수정
-  업체 구분 버튼 장묘 제외 누르면 알림 뜨도록
-   업체 수정 대표 사진 삭제하고 완료 누르면 api 호출 안 되도록 수정
-   오류 알림 뜨는 로직 수정

- middle Button에 diabled props 추가

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> - ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?